### PR TITLE
Add info for template context processors.

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -26,6 +26,13 @@ Add ``calendarium`` (and the ``filer`` dependencies) to your ``INSTALLED_APPS``:
         'calendarium',
     )
 
+Add ``django.core.context_processors.request`` to your ``TEMPLATE_CONTEXT_PROCESSORS``::
+
+    TEMPLATE_CONTEXT_PROCESSORS = (
+        ...,
+        'django.core.context_processors.request',
+    )
+
 Add the urls to your main ``urls.py``::
 
     urlpatterns = patterns('',


### PR DESCRIPTION
I couldn't figure out how to add events to the calendar using the
default templates. The calendar_month.html template references
the request variable, which is only available if you add the
django.core.context_processors.request processor to the
TEMPLATE_CONTEXT_PROCESSORS setting.  Doing so will display the
'Create new event' link.
