### PR TITLE
Update urls.py to work with Django 1.6

### DIFF
--- a/calendarium/urls.py
+++ b/calendarium/urls.py
@@ -1,5 +1,5 @@
 """URLs for the ``calendarium`` app."""
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from calendarium.views import (
     CalendariumRedirectView,


### PR DESCRIPTION
In Django 1.6, the usage of django.conf.urls.defaults
has been deprecated.

Both pattern and url can be imported from django.conf.urls
