### PR TITLE
models: add default value to Occurrence.cancelled.

### DIFF
--- a/calendarium/models.py
+++ b/calendarium/models.py
@@ -393,6 +393,7 @@ class Occurrence(EventModelMixin):
 
     cancelled = models.BooleanField(
         verbose_name=_('Cancelled'),
+        default=False,
     )
 
     title = models.CharField(


### PR DESCRIPTION
Avoid the following warning in Django 1.7:

```
System check identified some issues:

WARNINGS:
calendarium.Occurrence.cancelled: (1_6.W002) BooleanField does not have a default value.
        HINT: Django 1.6 changed the default value of BooleanField from False to None. See https://docs.djangoproject.com/en/1.6/ref/models/fields/#booleanfield for more information.
```
