### PR TITLE
forms: add empty `exclude` list to OccurrenceForm.

### DIFF
--- a/calendarium/forms.py
+++ b/calendarium/forms.py
@@ -37,6 +37,7 @@ class OccurrenceForm(forms.ModelForm):
 
     class Meta:
         model = Occurrence
+        exclude = []
 
     def save(self):
         cleaned_data = self.cleaned_data


### PR DESCRIPTION
Avoid the following warning when using Django 1.7:

```
RemovedInDjango18Warning: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is deprecated - form OccurrenceForm needs updating
  class OccurrenceForm(forms.ModelForm):
```
