### PR TITLE
docs: Fix a few typos

### DIFF
--- a/calendarium/tests/forms_tests.py
+++ b/calendarium/tests/forms_tests.py
@@ -104,7 +104,7 @@ class OccurrenceFormTestCase(TestCase):
                 'When save is called, the occurrence\'s start time should be'
                 ' set forward one hour.'))
 
-        # Case 3: Altering everthing from occurrence 4 to 6 to one day later
+        # Case 3: Altering everything from occurrence 4 to 6 to one day later
         occ_to_use = self.rec_occurrence_list[4]
         data = model_to_dict(occ_to_use)
         initial = data.copy()

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -8,7 +8,7 @@ want to add the calendar for the current month first. Reverse with::
 
 Then use the different URLs to let the user navigate through months, weeks and
 days. The event management should be intuitive. Be sure to add ``Rule`` models,
-if you want to use occurences.
+if you want to use occurrences.
 
 Template Tags
 -------------


### PR DESCRIPTION
There are small typos in:
- calendarium/tests/forms_tests.py
- docs/source/usage.rst

Fixes:
- Should read `everything` rather than `everthing`.
- Should read `occurrences` rather than `occurences`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md